### PR TITLE
Add `shutdown` handler. Exit process on `exit` handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -475,8 +475,13 @@ func TextDocumentDidOpen(ctx context.Context, vs lsp.DidOpenTextDocumentParams) 
 	return nil
 }
 
-func Exit(ctx context.Context, vs lsp.None) error {
+func Shutdown(ctx context.Context, vs lsp.None) error {
 	os.Remove(tempFile.Name())
+	return nil
+}
+
+func Exit(ctx context.Context, vs lsp.None) error {
+	os.Exit(0)
 	return nil
 }
 
@@ -593,6 +598,7 @@ func main() {
 		//"textDocument/references": handler.New(TextDocumentReferences),
 		//"textDocument/codeLens": handler.New(TextDocumentCodeLens),
 		"exit":            handler.New(Exit),
+		"shutdown":        handler.New(Shutdown),
 		"$/cancelRequest": handler.New(CancelRequest),
 	}, &jrpc2.ServerOptions{
 		AllowPush: true,

--- a/main.go
+++ b/main.go
@@ -481,6 +481,7 @@ func Shutdown(ctx context.Context, vs lsp.None) error {
 }
 
 func Exit(ctx context.Context, vs lsp.None) error {
+	os.Remove(tempFile.Name())
 	os.Exit(0)
 	return nil
 }


### PR DESCRIPTION
VSCode has a language client with a method `stop` which **appears** to call `shutdown` then `exit` in turn. I'm using this method to stop the LSP so I can then download a new binary in place of the existing one. Currently the code fails as the processing is still running. 

To fix this I have:

- I've added a `shutdown` handler
- `exit` will close the language server process. 

Does that sound alright?