### PR TITLE
Fixes #29 - Adjusted variables to check against

### DIFF
--- a/tfstructs/diags.go
+++ b/tfstructs/diags.go
@@ -74,6 +74,8 @@ func GetDiagnostics(fileName string, originalFile string) []lsp.Diagnostic {
 		"var":    cty.DynamicVal, // Need to check for undefined vars
 		"module": cty.DynamicVal,
 		"local":  cty.DynamicVal,
+		"each":   cty.DynamicVal,
+		"count":  cty.DynamicVal,
 	}
 
 	for k, v := range resourceTypes {


### PR DESCRIPTION
I added both "count" and "each" since they are potential dynamics that
could be in a resource. This feels a little like it could be more
automated to gather the variable context from each resource vs having to
define these variables manually.

NOTE: This change (and this method of variable definition in contexts in
general) introuces false positives. An example is using the 'each'
variable in a place where you have not also used the 'for_each'
attribute on a resource. The parser language server will PASS but
terraform will fail.