### PR TITLE
nix: make composable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
-with import <nixpkgs> {};
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
 
 buildGo112Module rec {
 


### PR DESCRIPTION
allow users to import the repo and then inject their own version of
nixpkgs.

For example with [niv][niv]:

    $ niv add juliosueiras/terraform-lsp

Then in the target project's overlay.nix:

    self: super: {
      sources = import ./nix/sources.nix;
      terraform-lsp = self.callPackage sources.terraform-lsp {};
    }

[niv]: https://github.com/nmattia/niv