### PR TITLE
[fix] add .terraform dir to scan provider target

### DIFF
--- a/tfstructs/provider.go
+++ b/tfstructs/provider.go
@@ -162,6 +162,10 @@ func pluginDirs(targetDir string) ([]string, error) {
 	vendorDir := filepath.Join("terraform.d", "plugins", arch)
 	dirs = append(dirs, vendorDir)
 
+	// current .terraform directory
+	currentDir := filepath.Join(".terraform", "plugins", arch)
+	dirs = append(dirs, currentDir)
+
 	// home dir will be searched afterward
 	homeDir, err := homedir.Dir()
 	if err != nil {

--- a/tfstructs/provider.go
+++ b/tfstructs/provider.go
@@ -171,7 +171,7 @@ func pluginDirs(targetDir string) ([]string, error) {
 	// auto installed directory
 	// This does not take into account overriding the data directory.
 	autoInstalledDir := ""
-	for dir := targetDir; dir != "" && strings.HasPrefix(dir, homeDir); dir = filepath.Dir(dir) {
+	for dir := targetDir; dir != ""; dir = filepath.Dir(dir) {
 		log.Printf("[DEBUG] search .terraform dir in %s", dir)
 		if _, err := os.Stat(filepath.Join(dir, ".terraform")); err == nil {
 			autoInstalledDir = filepath.Join(dir, ".terraform", "plugins", arch)

--- a/tfstructs/provider.go
+++ b/tfstructs/provider.go
@@ -162,10 +162,6 @@ func pluginDirs(targetDir string) ([]string, error) {
 	vendorDir := filepath.Join("terraform.d", "plugins", arch)
 	dirs = append(dirs, vendorDir)
 
-	// current .terraform directory
-	currentDir := filepath.Join(".terraform", "plugins", arch)
-	dirs = append(dirs, currentDir)
-
 	// home dir will be searched afterward
 	homeDir, err := homedir.Dir()
 	if err != nil {


### PR DESCRIPTION
In my environment, running `terraform init` will create a .terraform in the current directory.
This is not a search for providers by default