### PR TITLE
Features/tcp server

### DIFF
--- a/helper/file.go
+++ b/helper/file.go
@@ -88,11 +88,11 @@ func FindOffset(fileText string, line, column int) int {
 }
 
 func DumpLog(res interface{}) {
-  result := spew.Sdump(res)
-  strSlice:=strings.Split(result, "\n")
-  for _, s := range strSlice {
-    log.Debug(s)
-  }
+	result := spew.Sdump(res)
+	strSlice := strings.Split(result, "\n")
+	for _, s := range strSlice {
+		log.Debug(s)
+	}
 }
 
 func ParseVariables(vars hcl.Traversal, configVars map[string]*configs.Variable, completionItems []lsp.CompletionItem) []lsp.CompletionItem {

--- a/langserver/did_change.go
+++ b/langserver/did_change.go
@@ -19,9 +19,11 @@ func TextDocumentDidChange(ctx context.Context, vs lsp.DidChangeTextDocumentPara
 
 	DiagsFiles[fileURL] = tfstructs.GetDiagnostics(tempFile.Name(), fileURL)
 
-	TextDocumentPublishDiagnostics(Server, ctx, lsp.PublishDiagnosticsParams{
-		URI:         vs.TextDocument.URI,
-		Diagnostics: DiagsFiles[fileURL],
-	})
+	if !isTCP {
+		TextDocumentPublishDiagnostics(StdioServer, ctx, lsp.PublishDiagnosticsParams{
+			URI:         vs.TextDocument.URI,
+			Diagnostics: DiagsFiles[fileURL],
+		})
+	}
 	return nil
 }

--- a/langserver/did_change.go
+++ b/langserver/did_change.go
@@ -19,11 +19,9 @@ func TextDocumentDidChange(ctx context.Context, vs lsp.DidChangeTextDocumentPara
 
 	DiagsFiles[fileURL] = tfstructs.GetDiagnostics(tempFile.Name(), fileURL)
 
-	if !isTCP {
-		TextDocumentPublishDiagnostics(StdioServer, ctx, lsp.PublishDiagnosticsParams{
-			URI:         vs.TextDocument.URI,
-			Diagnostics: DiagsFiles[fileURL],
-		})
-	}
+  TextDocumentPublishDiagnostics(ctx, lsp.PublishDiagnosticsParams{
+    URI:         vs.TextDocument.URI,
+    Diagnostics: DiagsFiles[fileURL],
+  })
 	return nil
 }

--- a/langserver/did_open.go
+++ b/langserver/did_open.go
@@ -15,10 +15,12 @@ func TextDocumentDidOpen(ctx context.Context, vs lsp.DidOpenTextDocumentParams) 
 
 	DiagsFiles[fileURL] = tfstructs.GetDiagnostics(fileURL, fileURL)
 
-	TextDocumentPublishDiagnostics(Server, ctx, lsp.PublishDiagnosticsParams{
-		URI:         vs.TextDocument.URI,
-		Diagnostics: DiagsFiles[fileURL],
-	})
+	if !isTCP {
+		TextDocumentPublishDiagnostics(StdioServer, ctx, lsp.PublishDiagnosticsParams{
+			URI:         vs.TextDocument.URI,
+			Diagnostics: DiagsFiles[fileURL],
+		})
+	}
 	tempFile.Write([]byte(vs.TextDocument.Text))
 	return nil
 }

--- a/langserver/did_open.go
+++ b/langserver/did_open.go
@@ -15,12 +15,10 @@ func TextDocumentDidOpen(ctx context.Context, vs lsp.DidOpenTextDocumentParams) 
 
 	DiagsFiles[fileURL] = tfstructs.GetDiagnostics(fileURL, fileURL)
 
-	if !isTCP {
-		TextDocumentPublishDiagnostics(StdioServer, ctx, lsp.PublishDiagnosticsParams{
-			URI:         vs.TextDocument.URI,
-			Diagnostics: DiagsFiles[fileURL],
-		})
-	}
+  TextDocumentPublishDiagnostics(ctx, lsp.PublishDiagnosticsParams{
+    URI:         vs.TextDocument.URI,
+    Diagnostics: DiagsFiles[fileURL],
+  })
 	tempFile.Write([]byte(vs.TextDocument.Text))
 	return nil
 }

--- a/langserver/document_link.go
+++ b/langserver/document_link.go
@@ -2,42 +2,42 @@ package langserver
 
 import (
 	"context"
-	lsp "github.com/sourcegraph/go-lsp"
 	log "github.com/sirupsen/logrus"
+	lsp "github.com/sourcegraph/go-lsp"
 )
 
 type documentLinkParams struct {
-  TextDocument lsp.TextDocumentItem `json:"textDocument"`
+	TextDocument lsp.TextDocumentItem `json:"textDocument"`
 }
 
 type DocumentLink struct {
-  Range lsp.Range `json:"range"`
+	Range lsp.Range `json:"range"`
 
-  /**
-  * The uri this link points to. If missing a resolve request is sent later.
-  */
-  Target string `json:"target"`
+	/**
+	 * The uri this link points to. If missing a resolve request is sent later.
+	 */
+	Target string `json:"target"`
 
-  Tooltip string `json:"tooltip"`
+	Tooltip string `json:"tooltip"`
 }
 
 func TextDocumentDocumentLink(ctx context.Context, vs documentLinkParams) ([]DocumentLink, error) {
-  log.Info(vs)
+	log.Info(vs)
 
-  return []DocumentLink{
-    DocumentLink{
-      Range: lsp.Range{
-        Start: lsp.Position{
-          Line: 1,
-          Character: 1,
-        },
-        End: lsp.Position{
-          Line: 1,
-          Character: 10,
-        },
-      },
-      Target: "https://github.com",
-      Tooltip: "https://github.com",
-    },
-  }, nil
+	return []DocumentLink{
+		DocumentLink{
+			Range: lsp.Range{
+				Start: lsp.Position{
+					Line:      1,
+					Character: 1,
+				},
+				End: lsp.Position{
+					Line:      1,
+					Character: 10,
+				},
+			},
+			Target:  "https://github.com",
+			Tooltip: "https://github.com",
+		},
+	}, nil
 }

--- a/langserver/initialize.go
+++ b/langserver/initialize.go
@@ -9,18 +9,18 @@ import (
 )
 
 type DocumentLinkOptions struct {
-  ResolveProvider bool `json:"resolveProvider,omitempty"`
+	ResolveProvider bool `json:"resolveProvider,omitempty"`
 }
 
 type ExtendedServerCapabilities struct {
-  TextDocumentSync *lsp.TextDocumentSyncOptionsOrKind `json:"textDocumentSync,omitempty"`
-  CompletionProvider *lsp.CompletionOptions `json:"completionProvider,omitempty"`
-  HoverProvider bool `json:"hoverProvider,omitempty"`
-  DocumentLinkProvider *DocumentLinkOptions `json:"documentLinkProvider,omitempty"`
+	TextDocumentSync     *lsp.TextDocumentSyncOptionsOrKind `json:"textDocumentSync,omitempty"`
+	CompletionProvider   *lsp.CompletionOptions             `json:"completionProvider,omitempty"`
+	HoverProvider        bool                               `json:"hoverProvider,omitempty"`
+	DocumentLinkProvider *DocumentLinkOptions               `json:"documentLinkProvider,omitempty"`
 }
 
 type ExtendedInitializeResult struct {
-  Capabilities ExtendedServerCapabilities `json:"capabilities"`
+	Capabilities ExtendedServerCapabilities `json:"capabilities"`
 }
 
 func Initialize(ctx context.Context, vs lsp.InitializeParams) (ExtendedInitializeResult, error) {
@@ -45,7 +45,7 @@ func Initialize(ctx context.Context, vs lsp.InitializeParams) (ExtendedInitializ
 			},
 			HoverProvider: false,
 			DocumentLinkProvider: &DocumentLinkOptions{
-				ResolveProvider:   false,
+				ResolveProvider: false,
 			},
 		},
 	}, nil

--- a/langserver/initialized.go
+++ b/langserver/initialized.go
@@ -1,0 +1,11 @@
+package langserver
+
+import (
+	"context"
+)
+
+type InitializedParams struct {}
+
+func Initialized(ctx context.Context, vs InitializedParams) error {
+  return nil
+}

--- a/langserver/main.go
+++ b/langserver/main.go
@@ -77,6 +77,7 @@ func RunTCPServer(port int) {
 func InitializeServiceMap() {
 	ServiceMap = handler.Map{
 		"initialize":                handler.New(Initialize),
+		"initialized":                handler.New(Initialized),
 		"textDocument/completion":   handler.New(TextDocumentComplete),
 		"textDocument/didChange":    handler.New(TextDocumentDidChange),
 		"textDocument/didOpen":      handler.New(TextDocumentDidOpen),

--- a/langserver/main.go
+++ b/langserver/main.go
@@ -16,20 +16,7 @@ import (
 func RunStdioServer() {
 	isTCP = false
 
-	StdioServer = jrpc2.NewServer(handler.Map{
-		"initialize":                handler.New(Initialize),
-		"textDocument/completion":   handler.New(TextDocumentComplete),
-		"textDocument/didChange":    handler.New(TextDocumentDidChange),
-		"textDocument/didOpen":      handler.New(TextDocumentDidOpen),
-		"textDocument/didClose":     handler.New(TextDocumentDidClose),
-		"textDocument/documentLink": handler.New(TextDocumentDocumentLink),
-		//"textDocument/hover":      handler.New(TextDocumentHover),
-		//"textDocument/references": handler.New(TextDocumentReferences),
-		//"textDocument/codeLens": handler.New(TextDocumentCodeLens),
-		"exit":            handler.New(Exit),
-		"shutdown":        handler.New(Shutdown),
-		"$/cancelRequest": handler.New(CancelRequest),
-	}, &jrpc2.ServerOptions{
+	StdioServer = jrpc2.NewServer(ServiceMap, &jrpc2.ServerOptions{
 		AllowPush: true,
 	})
 
@@ -47,23 +34,6 @@ func RunStdioServer() {
 
 func RunTCPServer(port int) {
 	isTCP = true
-
-	ServiceMap = handler.Map{
-		"initialize":                handler.New(Initialize),
-		"textDocument/completion":   handler.New(TextDocumentComplete),
-		"textDocument/didChange":    handler.New(TextDocumentDidChange),
-		"textDocument/didOpen":      handler.New(TextDocumentDidOpen),
-		"textDocument/didClose":     handler.New(TextDocumentDidClose),
-		"textDocument/documentLink": handler.New(TextDocumentDocumentLink),
-		//"textDocument/hover":      handler.New(TextDocumentHover),
-		//"textDocument/references": handler.New(TextDocumentReferences),
-		//"textDocument/codeLens": handler.New(TextDocumentCodeLens),
-		"exit":            handler.New(Exit),
-		"shutdown":        handler.New(Shutdown),
-		"$/cancelRequest": handler.New(CancelRequest),
-	}
-
-	// Start the server on a channel comprising stdin/stdout.
 
 	lst, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
@@ -101,5 +71,22 @@ func RunTCPServer(port int) {
 			log.Info(ctx.Err())
 			return
 		}
+	}
+}
+
+func InitializeServiceMap() {
+	ServiceMap = handler.Map{
+		"initialize":                handler.New(Initialize),
+		"textDocument/completion":   handler.New(TextDocumentComplete),
+		"textDocument/didChange":    handler.New(TextDocumentDidChange),
+		"textDocument/didOpen":      handler.New(TextDocumentDidOpen),
+		"textDocument/didClose":     handler.New(TextDocumentDidClose),
+		"textDocument/documentLink": handler.New(TextDocumentDocumentLink),
+		//"textDocument/hover":      handler.New(TextDocumentHover),
+		//"textDocument/references": handler.New(TextDocumentReferences),
+		//"textDocument/codeLens": handler.New(TextDocumentCodeLens),
+		"exit":            handler.New(Exit),
+		"shutdown":        handler.New(Shutdown),
+		"$/cancelRequest": handler.New(CancelRequest),
 	}
 }

--- a/langserver/main.go
+++ b/langserver/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/creachadair/jrpc2/handler"
 	"github.com/creachadair/jrpc2/server"
 	log "github.com/sirupsen/logrus"
+  oldLog "log"
 	"net"
 	"os"
 )
@@ -75,11 +76,14 @@ func RunTCPServer(port int) {
 
 	ctx, cancelFunc := context.WithCancel(ctx)
 
+  oldLogInstance := oldLog.New(os.Stdout, "", 0)
+
 	go func() {
 		if err := server.Loop(lst, ServiceMap, &server.LoopOptions{
 			Framing: newChan,
 			ServerOptions: &jrpc2.ServerOptions{
 				AllowPush: true,
+        Logger: oldLogInstance,
 			},
 		}); err != nil {
 			log.Errorf("Loop: unexpected failure: %v", err)

--- a/langserver/main.go
+++ b/langserver/main.go
@@ -2,6 +2,7 @@ package langserver
 
 import (
 	"context"
+  "fmt"
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/channel"
 	"github.com/creachadair/jrpc2/handler"
@@ -63,7 +64,7 @@ func RunTCPServer(port int) {
 
 	// Start the server on a channel comprising stdin/stdout.
 
-	lst, err := net.Listen("tcp", "127.0.0.1:9900")
+	lst, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		log.Fatalf("Listen: %v", err)
 	}

--- a/langserver/main.go
+++ b/langserver/main.go
@@ -1,17 +1,25 @@
 package langserver
 
 import (
+	"context"
 	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/channel"
 	"github.com/creachadair/jrpc2/handler"
+	"github.com/creachadair/jrpc2/server"
+	log "github.com/sirupsen/logrus"
+	"net"
+	"os"
 )
 
-func CreateServer() *jrpc2.Server {
-	Server = jrpc2.NewServer(handler.Map{
-		"initialize":              handler.New(Initialize),
-		"textDocument/completion": handler.New(TextDocumentComplete),
-		"textDocument/didChange":  handler.New(TextDocumentDidChange),
-		"textDocument/didOpen":    handler.New(TextDocumentDidOpen),
-		"textDocument/didClose":   handler.New(TextDocumentDidClose),
+func RunStdioServer() {
+	isTCP = false
+
+	StdioServer = jrpc2.NewServer(handler.Map{
+		"initialize":                handler.New(Initialize),
+		"textDocument/completion":   handler.New(TextDocumentComplete),
+		"textDocument/didChange":    handler.New(TextDocumentDidChange),
+		"textDocument/didOpen":      handler.New(TextDocumentDidOpen),
+		"textDocument/didClose":     handler.New(TextDocumentDidClose),
 		"textDocument/documentLink": handler.New(TextDocumentDocumentLink),
 		//"textDocument/hover":      handler.New(TextDocumentHover),
 		//"textDocument/references": handler.New(TextDocumentReferences),
@@ -23,5 +31,70 @@ func CreateServer() *jrpc2.Server {
 		AllowPush: true,
 	})
 
-	return Server
+	StdioServer.Start(channel.Header("")(os.Stdin, os.Stdout))
+
+	log.Info("Server started")
+
+	// Wait for the server to exit, and report any errors.
+	if err := StdioServer.Wait(); err != nil {
+		log.Printf("Server exited: %v", err)
+	}
+
+	log.Info("Server Finish")
+}
+
+func RunTCPServer(port int) {
+	isTCP = true
+
+	ServiceMap = handler.Map{
+		"initialize":                handler.New(Initialize),
+		"textDocument/completion":   handler.New(TextDocumentComplete),
+		"textDocument/didChange":    handler.New(TextDocumentDidChange),
+		"textDocument/didOpen":      handler.New(TextDocumentDidOpen),
+		"textDocument/didClose":     handler.New(TextDocumentDidClose),
+		"textDocument/documentLink": handler.New(TextDocumentDocumentLink),
+		//"textDocument/hover":      handler.New(TextDocumentHover),
+		//"textDocument/references": handler.New(TextDocumentReferences),
+		//"textDocument/codeLens": handler.New(TextDocumentCodeLens),
+		"exit":            handler.New(Exit),
+		"shutdown":        handler.New(Shutdown),
+		"$/cancelRequest": handler.New(CancelRequest),
+	}
+
+	// Start the server on a channel comprising stdin/stdout.
+
+	lst, err := net.Listen("tcp", "127.0.0.1:9900")
+	if err != nil {
+		log.Fatalf("Listen: %v", err)
+	}
+
+	newChan := channel.Header("")
+
+	ctx := context.Background()
+
+	ctx, cancelFunc := context.WithCancel(ctx)
+
+	go func() {
+		if err := server.Loop(lst, ServiceMap, &server.LoopOptions{
+			Framing: newChan,
+			ServerOptions: &jrpc2.ServerOptions{
+				AllowPush: true,
+			},
+		}); err != nil {
+			log.Errorf("Loop: unexpected failure: %v", err)
+			cancelFunc()
+			return
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Info("Server Finish")
+		err := lst.Close()
+		if err != nil {
+			log.Info("Server Finish")
+			log.Info(ctx.Err())
+			return
+		}
+	}
 }

--- a/langserver/publish_diagnostics.go
+++ b/langserver/publish_diagnostics.go
@@ -6,7 +6,15 @@ import (
 	lsp "github.com/sourcegraph/go-lsp"
 )
 
-func TextDocumentPublishDiagnostics(server *jrpc2.Server, ctx context.Context, vs lsp.PublishDiagnosticsParams) error {
+func TextDocumentPublishDiagnostics(ctx context.Context, vs lsp.PublishDiagnosticsParams) error {
 
-	return server.Push(ctx, "textDocument/publishDiagnostics", vs)
+  var resultedError error
+
+  if isTCP {
+    resultedError = jrpc2.ServerPush(ctx, "textDocument/publishDiagnostics", vs)
+  } else {
+    resultedError = StdioServer.Push(ctx, "textDocument/publishDiagnostics", vs)
+  }
+
+	return resultedError
 }

--- a/langserver/temp.go
+++ b/langserver/temp.go
@@ -8,4 +8,6 @@ import (
 
 var tempFile afero.File
 var DiagsFiles = make(map[string][]lsp.Diagnostic)
-var Server *jrpc2.Server
+var StdioServer *jrpc2.Server
+var ServiceMap jrpc2.Assigner
+var isTCP bool

--- a/main.go
+++ b/main.go
@@ -52,6 +52,8 @@ func main() {
 		log.SetOutput(f)
 	}
 
+  langserver.InitializeServiceMap()
+
 	if *tcp {
 		langserver.RunTCPServer(*port)
 	} else {

--- a/main.go
+++ b/main.go
@@ -4,15 +4,16 @@ import (
 	"flag"
 	"fmt"
 	log "github.com/sirupsen/logrus"
+	"io/ioutil"
 	oldLog "log"
 	"os"
 	"strings"
 
-	"github.com/creachadair/jrpc2/channel"
 	"github.com/juliosueiras/terraform-lsp/langserver"
-	"io/ioutil"
 )
 
+var tcp = flag.Bool("tcp", false, "Use TCP instead of Stdio(which is default)")
+var port = flag.Int("port", 9900, "Port for TCP Server")
 var location = flag.String("log-location", "", "Location of the lsp log")
 var debug = flag.Bool("debug", false, "Enable debug output")
 var enableLogFile = flag.Bool("enable-log-file", false, "Enable log file")
@@ -34,8 +35,6 @@ func main() {
 		return
 	}
 
-	Server := langserver.CreateServer()
-
 	log.Infof("Log Level is Debug: %t", *debug)
 
 	if *debug {
@@ -53,14 +52,9 @@ func main() {
 		log.SetOutput(f)
 	}
 
-	// Start the server on a channel comprising stdin/stdout.
-	Server.Start(channel.Header("")(os.Stdin, os.Stdout))
-	log.Info("Server started")
-
-	// Wait for the server to exit, and report any errors.
-	if err := Server.Wait(); err != nil {
-		log.Printf("Server exited: %v", err)
+	if *tcp {
+		langserver.RunTCPServer(*port)
+	} else {
+		langserver.RunStdioServer()
 	}
-
-	log.Info("Server Finish")
 }

--- a/main.go
+++ b/main.go
@@ -14,9 +14,16 @@ import (
 
 var tcp = flag.Bool("tcp", false, "Use TCP instead of Stdio(which is default)")
 var port = flag.Int("port", 9900, "Port for TCP Server")
+var address = flag.String("address", "127.0.0.1", "Address for TCP Server")
+
 var location = flag.String("log-location", "", "Location of the lsp log")
+var locationJRPC2 = flag.String("log-jrpc2-location", "", "Location of the lsp log for jrpc2")
+
 var debug = flag.Bool("debug", false, "Enable debug output")
+var debugJRPC2 = flag.Bool("debug-jrpc2", false, "Enable debug output for jrpc2")
+
 var enableLogFile = flag.Bool("enable-log-file", false, "Enable log file")
+var enableLogFileJRPC2 = flag.Bool("enable-log-jrpc2-file", false, "Enable log file for JRPC2")
 
 var Version string
 var GitCommit string
@@ -52,11 +59,29 @@ func main() {
 		log.SetOutput(f)
 	}
 
+  var oldLogInstance *oldLog.Logger
+
+  if *debugJRPC2 {
+    if !*tcp && !*enableLogFileJRPC2 {
+      log.Fatal("Debug for JRPC2 has to be set for log file location if is set to use stdio")
+    }
+
+    oldLogInstance = oldLog.New(os.Stdout, "", 0)
+    if *enableLogFileJRPC2 {
+      f, err := os.OpenFile(fmt.Sprintf("%stf-lsp-jrpc2.log", *locationJRPC2), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+      if err != nil {
+        log.Fatalf("error opening file: %v", err)
+      }
+      defer f.Close()
+      oldLogInstance.SetOutput(f)
+    }
+	}
+
   langserver.InitializeServiceMap()
 
 	if *tcp {
-		langserver.RunTCPServer(*port)
+		langserver.RunTCPServer(*address, *port, oldLogInstance)
 	} else {
-		langserver.RunStdioServer()
+		langserver.RunStdioServer(oldLogInstance)
 	}
 }


### PR DESCRIPTION
Added TCP Server options and the following cli options as well:

- `-tcp` : to enable TCP server (default to stdio)
- `-address`: address for the tcp
- `-port`: port for the tcp

New debug options:
- `-debug-jrpc2`: enable logging for jrpc2
- `-enable-log-jrpc2-file`: enable file location logging for jrpc2
- `-log-jrpc2-location`: location to put `tf-lsp-jrpc2.log` in