### PR TITLE
Fix Issue with `date` and hardcoded bin dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
+DATE    := $$(date +%Y-%m-%dT%T%z)
+VERSION := $$(git describe --tags)
+COMMIT  := $$(git rev-list -1 HEAD)
+DST     ?= ~/.bin/
+
 default:
-	go build -ldflags "-X main.GitCommit=$$(git rev-list -1 HEAD) -X main.Version=$$(git describe --tags) -X main.Date=$$(date --rfc-3339=date)"
+	go build -ldflags "-X main.GitCommit=$(COMMIT) -X main.Version=$(VERSION) -X main.Date=$(DATE)"
 
 copy:
-	go build -ldflags "-X main.GitCommit=$$(git rev-list -1 HEAD) -X main.Version=$$(git describe --tags) -X main.Date=$$(date --rfc-3339=date)" && cp ./terraform-lsp ~/.bin/ && cp ./terraform-lsp ~/
+	go build -ldflags "-X main.GitCommit=$(COMMIT) -X main.Version=$(VERSION) -X main.Date=$(DATE)" && cp ./terraform-lsp $(DST) && cp ./terraform-lsp ~/
 
 .PHONY: copy

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,15 @@ VERSION := $$(git describe --tags)
 COMMIT  := $$(git rev-list -1 HEAD)
 DST     ?= ~/.bin/
 
-default:
+terraform-lsp:
 	go build -ldflags "-X main.GitCommit=$(COMMIT) -X main.Version=$(VERSION) -X main.Date=$(DATE)"
 
-copy:
-	go build -ldflags "-X main.GitCommit=$(COMMIT) -X main.Version=$(VERSION) -X main.Date=$(DATE)" && cp ./terraform-lsp $(DST) && cp ./terraform-lsp ~/
+copy: terraform-lsp
+	cp ./terraform-lsp $(DST) && cp ./terraform-lsp ~/
 
-.PHONY: copy
+clean:
+	rm -f terraform-lsp
+
+default: terraform-lsp
+
+.PHONY: clean copy

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is LSP (Language Server Protocol) for Terraform
 
 **IMPORTANT:** Currently there is two terraform lsp, one is this one and the other one is [terraform-ls](https://github.com/hashicorp/terraform-ls), which contain details about this repo as well.
 
-The aim to have a unified lsp for terraform in the future, but for now there is two concurrent development with collabration to each other, this repo is aim for more experimental features, and the terraform-ls is aim for stableness 
+The aim to have a unified lsp for terraform in the future, but for now there is two concurrent development with collabration to each other, this repo is aim for more experimental features, and the terraform-ls is aim for stableness
 
 **NOTE:** This is first stage of the plugin, so is experimental
 
@@ -46,6 +46,12 @@ it will need Go 1.14+
 GO111MODULE=on go mod download # Download the modules for the project
 make      # Build the project. Alternatively run "go build"
 make copy # Install the project
+```
+
+you may also specify a path to your preferred bin directory with the `DST` parameter
+
+```sh
+make copy DST="$your_preferred_bin_path" # Install the project
 ```
 
 ### Nixpkgs
@@ -101,7 +107,7 @@ All Todos are listed [here](Todo.md)
 
 ## Bugs
 - Order of completion items
-- Issue with block 
+- Issue with block
 
 ## Credits
 - LSP structure using [Sourcegraph's go-lsp](https://github.com/sourcegraph/go-lsp)


### PR DESCRIPTION
macos default `date` command doesn't seem to have the
`--rfc-3339=date` flag. So this switches to a presumably more
universal format string.

also adds the ability to override the default `DST` to `~/$(BIN)`
directories other than ~/.bin, and pulls shared commands into Make variables.