### PR TITLE
fix: Create destination directory if it does not exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@ DST     ?= ~/.bin/
 terraform-lsp:
 	go build -ldflags "-X main.GitCommit=$(COMMIT) -X main.Version=$(VERSION) -X main.Date=$(DATE)"
 
-copy: terraform-lsp
+copy: terraform-lsp | create-dir
 	cp ./terraform-lsp $(DST) && cp ./terraform-lsp ~/
+
+create-dir:
+	mkdir -p $(DST)
 
 clean:
 	rm -f terraform-lsp


### PR DESCRIPTION
1. Why is this change neccesary?
Because the destination directory may not exist on the users machine.

2. How does it address the issue?
By implementing an [order-only prerequisite](https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html) to the copy recipe that creates the
destination directory if it does not exist.

3. What side effects does this change have?
None!

Closes #83 